### PR TITLE
Add custom mutator for SizedBytes

### DIFF
--- a/tezos/encoding/src/fuzzing/mod.rs
+++ b/tezos/encoding/src/fuzzing/mod.rs
@@ -2,3 +2,4 @@
 // SPDX-License-Identifier: MIT
 
 pub mod bigint;
+pub mod sizedbytes;

--- a/tezos/encoding/src/fuzzing/sizedbytes.rs
+++ b/tezos/encoding/src/fuzzing/sizedbytes.rs
@@ -1,0 +1,64 @@
+use crate::types::SizedBytes;
+
+use fuzzcheck::mutators::{
+    fixed_len_vector::FixedLenVecMutator, integer::U8Mutator, map::MapMutator,
+};
+use fuzzcheck::MutatorWrapper;
+
+type SizedBytesMutatorInner<const SIZE: usize> = MapMutator<
+    Vec<u8>,
+    SizedBytes<SIZE>,
+    FixedLenVecMutator<u8, U8Mutator>,
+    fn(&SizedBytes<SIZE>) -> Option<Vec<u8>>,
+    fn(&Vec<u8>) -> SizedBytes<SIZE>,
+    fn(&SizedBytes<SIZE>, f64) -> f64,
+>;
+pub struct SizedBytesMutator<const SIZE: usize>(SizedBytesMutatorInner<SIZE>);
+
+#[no_coverage]
+fn vec_from_sizedbytes<const SIZE: usize>(sb: &SizedBytes<SIZE>) -> Option<Vec<u8>> {
+    Some(sb.0.to_vec())
+}
+
+#[no_coverage]
+fn sizedbytes_from_vec<const SIZE: usize>(v: &Vec<u8>) -> SizedBytes<SIZE> {
+    let bytes: [u8; SIZE] = v[0..SIZE].try_into().unwrap();
+    SizedBytes::<SIZE>::from(bytes)
+}
+
+#[no_coverage]
+fn complexity<const SIZE: usize>(_t: &SizedBytes<SIZE>, cplx: f64) -> f64 {
+    cplx
+}
+
+impl<const SIZE: usize> SizedBytesMutator<SIZE> {
+    #[no_coverage]
+    pub fn new() -> Self {
+        Self {
+            0: MapMutator::new(
+                FixedLenVecMutator::<u8, U8Mutator>::new_with_repeated_mutator(
+                    U8Mutator::default(),
+                    SIZE,
+                ),
+                vec_from_sizedbytes,
+                sizedbytes_from_vec,
+                complexity,
+            ),
+        }
+    }
+}
+
+impl<const SIZE: usize> MutatorWrapper for SizedBytesMutator<SIZE> {
+    type Wrapped = SizedBytesMutatorInner<SIZE>;
+
+    fn wrapped_mutator(&self) -> &Self::Wrapped {
+        &self.0
+    }
+}
+
+impl<const SIZE: usize> Default for SizedBytesMutator<SIZE> {
+    #[no_coverage]
+    fn default() -> Self {
+        SizedBytesMutator::<SIZE>::new()
+    }
+}

--- a/tezos/encoding/src/types.rs
+++ b/tezos/encoding/src/types.rs
@@ -165,7 +165,7 @@ impl From<&Mutez> for BigInt {
 has_encoding!(Mutez, MUTEZ_ENCODING, { Encoding::Mutez });
 
 #[derive(Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "fuzzing", derive(fuzzcheck::DefaultMutator))]
+//#[cfg_attr(feature = "fuzzing", derive(fuzzcheck::DefaultMutator))]
 pub struct SizedBytes<const SIZE: usize>(pub [u8; SIZE]);
 
 impl<const SIZE: usize> std::fmt::Display for SizedBytes<SIZE> {

--- a/tezos/messages/src/protocol/proto_001/operation.rs
+++ b/tezos/messages/src/protocol/proto_001/operation.rs
@@ -14,6 +14,12 @@ use tezos_encoding::binary_reader::BinaryReaderError;
 use tezos_encoding::types::{Mutez, SizedBytes};
 use tezos_encoding::{enc::BinWriter, encoding::HasEncoding, nom::NomReader};
 
+#[cfg(feature = "fuzzing")]
+use tezos_encoding::fuzzing::sizedbytes::SizedBytesMutator;
+
+#[cfg(feature = "fuzzing")]
+use fuzzcheck::mutators::option::OptionMutator;
+
 use crate::base::signature_public_key::{SignaturePublicKey, SignaturePublicKeyHash};
 use crate::Timestamp;
 
@@ -109,6 +115,7 @@ pub struct InlinedEndorsement {
 
 /// Full Header.
 /// See [https://tezos.gitlab.io/shell/p2p_api.html?highlight=p2p%20encodings#endorsement-tag-0].
+#[cfg_attr(feature = "fuzzing", derive(fuzzcheck::DefaultMutator))]
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, HasEncoding, NomReader, BinWriter)]
 pub struct FullHeader {
     #[encoding(builtin = "Int32")]
@@ -121,8 +128,10 @@ pub struct FullHeader {
     pub fitness: Fitness,
     pub context: ContextHash,
     pub priority: u16,
+    #[cfg_attr(feature = "fuzzing", field_mutator(SizedBytesMutator<8>))]
     pub proof_of_work_nonce: SizedBytes<8>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "fuzzing", field_mutator(OptionMutator<SizedBytes<32>, SizedBytesMutator<32>>))]
     pub seed_nonce_hash: Option<SizedBytes<32>>,
     pub signature: Signature,
 }
@@ -195,6 +204,7 @@ pub struct EndorsementOperation {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, HasEncoding, NomReader, BinWriter)]
 pub struct SeedNonceRevelationOperation {
     pub level: i32,
+    #[cfg_attr(feature = "fuzzing", field_mutator(SizedBytesMutator<32>))]
     pub nonce: SizedBytes<32>,
 }
 
@@ -224,6 +234,7 @@ pub struct DoubleBakingEvidenceOperation {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, HasEncoding, NomReader, BinWriter)]
 pub struct ActivateAccountOperation {
     pub pkh: ContractTz1Hash,
+    #[cfg_attr(feature = "fuzzing", field_mutator(SizedBytesMutator<20>))]
     pub secret: SizedBytes<20>,
 }
 

--- a/tezos/messages/src/protocol/proto_010/operation.rs
+++ b/tezos/messages/src/protocol/proto_010/operation.rs
@@ -22,6 +22,12 @@ use tezos_encoding::binary_reader::BinaryReaderError;
 use tezos_encoding::types::SizedBytes;
 use tezos_encoding::{enc::BinWriter, encoding::HasEncoding, nom::NomReader};
 
+#[cfg(feature = "fuzzing")]
+use tezos_encoding::fuzzing::sizedbytes::SizedBytesMutator;
+
+#[cfg(feature = "fuzzing")]
+use fuzzcheck::mutators::option::OptionMutator;
+
 use crate::p2p::encoding::{
     block_header::Level, fitness::Fitness, operation::Operation as P2POperation,
 };
@@ -178,8 +184,10 @@ pub struct FullHeader {
     pub fitness: Fitness,
     pub context: ContextHash,
     pub priority: u16,
+    #[cfg_attr(feature = "fuzzing", field_mutator(SizedBytesMutator<8>))]
     pub proof_of_work_nonce: SizedBytes<8>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "fuzzing", field_mutator(OptionMutator<SizedBytes<32>, SizedBytesMutator<32>>))]
     pub seed_nonce_hash: Option<SizedBytes<32>>,
     pub liquidity_baking_escape_vote: bool,
     pub signature: Signature,

--- a/tezos/messages/src/protocol/proto_011/operation.rs
+++ b/tezos/messages/src/protocol/proto_011/operation.rs
@@ -25,6 +25,12 @@ use tezos_encoding::{
     types::{Mutez, SizedBytes},
 };
 
+#[cfg(feature = "fuzzing")]
+use tezos_encoding::fuzzing::sizedbytes::SizedBytesMutator;
+
+#[cfg(feature = "fuzzing")]
+use fuzzcheck::mutators::option::OptionMutator;
+
 use crate::{
     base::signature_public_key::SignaturePublicKeyHash,
     p2p::encoding::{block_header::Level, fitness::Fitness, operation::Operation as P2POperation},
@@ -158,6 +164,7 @@ pub enum Contents {
 
 /// Register_global_constant (tag 111).
 /// See [https://tezos.gitlab.io/shell/p2p_api.html?highlight=p2p%20encodings#register-global-constant-tag-111].
+#[cfg_attr(feature = "fuzzing", derive(fuzzcheck::DefaultMutator))]
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, HasEncoding, NomReader, BinWriter)]
 pub struct RegisterGlobalConstantOperation {
     pub source: SignaturePublicKeyHash,
@@ -195,8 +202,10 @@ pub struct FullHeader {
     pub fitness: Fitness,
     pub context: ContextHash,
     pub priority: u16,
+    #[cfg_attr(feature = "fuzzing", field_mutator(SizedBytesMutator<8>))]
     pub proof_of_work_nonce: SizedBytes<8>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "fuzzing", field_mutator(OptionMutator<SizedBytes<32>, SizedBytesMutator<32>>))]
     pub seed_nonce_hash: Option<SizedBytes<32>>,
     pub liquidity_baking_escape_vote: bool,
     pub signature: Signature,

--- a/tezos/messages/src/protocol/proto_012/operation.rs
+++ b/tezos/messages/src/protocol/proto_012/operation.rs
@@ -33,6 +33,10 @@ use tezos_encoding::{
     nom::NomReader,
     types::{Mutez, SizedBytes},
 };
+
+#[cfg(feature = "fuzzing")]
+use tezos_encoding::fuzzing::sizedbytes::SizedBytesMutator;
+
 use tezos_encoding_derive::BinWriter;
 
 use crate::{
@@ -312,6 +316,7 @@ pub struct FullHeader {
     pub context: ContextHash,
     pub payload_hash: BlockPayloadHash,
     pub payload_round: i32,
+    #[cfg_attr(feature = "fuzzing", field_mutator(SizedBytesMutator<8>))]
     pub proof_of_work_nonce: SizedBytes<8>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub seed_nonce_hash: Option<NonceHash>,


### PR DESCRIPTION
 Add custom mutator for `SizedBytes` type and wrap instances of use with `field_mutator`.

This is a workaround for a limitation of *fuzzcheck* which can not parse `ConstParam` expressions. Moreover, *fuzzcheck* uses its own parser (https://github.com/loiclec/decent-synquote-alternative), so producing a proper fix will require more effort.